### PR TITLE
Update Dependencies & Fix IP Resolution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amaabca/red

--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk", ">= 2.0"
+  spec.add_dependency "aws-sdk-core", ">= 2.0"
+  spec.add_dependency "aws-sdk-ec2", ">= 1.0"
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"

--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,5 +1,6 @@
 require 'capistrano/configuration'
-require 'aws-sdk'
+require 'aws-sdk-core'
+require 'aws-sdk-ec2'
 require 'colorize'
 require 'terminal-table'
 require 'yaml'

--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 module CapEC2
   class EC2Handler

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 module CapEC2
   module Utils
@@ -42,7 +42,11 @@ module CapEC2
       ec2_interface = contact_point_mapping[fetch(:ec2_contact_point)]
       return instance.send(ec2_interface) if ec2_interface
 
-      instance.public_dns_name || instance.public_ip_address || instance.private_ip_address
+      [
+        instance.public_dns_name,
+        instance.public_ip_address,
+        instance.private_ip_address
+      ].map(&:to_s).reject(&:empty?).first
     end
 
     def load_config

--- a/lib/cap-ec2/version.rb
+++ b/lib/cap-ec2/version.rb
@@ -1,3 +1,3 @@
 module CapEC2
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end


### PR DESCRIPTION
* We only need aws-sdk-core and aws-sdk-ec2. Relax restrictions to
  reduce dependency footprint and make dependency resolution easier.
* ```public_dns_name``` can come back as a blank string, resulting in
  improper ```contact_point``` resolution. Find the first value that
  is present and return that.
* bump version to 1.1.3